### PR TITLE
Failed to throw properly formed error in some cases of catastrophic index failure

### DIFF
--- a/worker/components/database.js
+++ b/worker/components/database.js
@@ -515,7 +515,7 @@ class Database {
     async _decompress(buffer) {
         return new Promise((resolve, reject) => {
             this._zlib.gunzip(buffer, null, (err, data) => {
-                if (err) reject();
+                if (err) reject(err);
                 else resolve(data.toString('utf8'));
             });
         });


### PR DESCRIPTION
The `database._decompress` process was failing to pass up any errors that `zlib` threw during index inflation.
This was causing stores with this issue to deadlock, unable to proceed to index recovery. 